### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete string escaping or encoding

### DIFF
--- a/sqli/static/js/materialize.js
+++ b/sqli/static/js/materialize.js
@@ -1328,7 +1328,7 @@ Materialize.guid = function () {
  * @returns {string}
  */
 Materialize.escapeHash = function (hash) {
-  return hash.replace(/(:|\.|\[|\]|,|=)/g, "\\$1");
+  return hash.replace(/\\/g, "\\\\").replace(/(:|\.|\[|\]|,|=)/g, "\\$1");
 };
 
 Materialize.elementOrParentIsFixed = function (element) {


### PR DESCRIPTION
Potential fix for [https://github.com/CSantanaOrg/dvpwa-demo/security/code-scanning/10](https://github.com/CSantanaOrg/dvpwa-demo/security/code-scanning/10)

To safely escape all intended special characters in the hash, we must also escape any backslashes that might be present in the input **before** escaping the other characters. The fix involves two replacement operations:

1. First, replace all backslashes in the input with double backslashes.
2. Next, escape all the special characters as before.

This is best achieved by chaining two `replace` calls: the first with `/\\/g` (which replaces every backslash with `\\`), and the second with the original `/(:|\.|\[|\]|,|=)/g` regex. The change should be applied only to the region around `Materialize.escapeHash` implementation, on line 1331 in sqli/static/js/materialize.js.

No new imports or definitions are needed; only in-place changes to the escaping function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
